### PR TITLE
Fix some error 500s on sign in and signup failures

### DIFF
--- a/users/adapter.py
+++ b/users/adapter.py
@@ -1,5 +1,3 @@
-import re
-
 from allauth.utils import build_absolute_uri
 from allauth.account.adapter import DefaultAccountAdapter
 
@@ -18,24 +16,6 @@ class AccountAdapter(DefaultAccountAdapter):
         return ret
 
     def render_mail(self, template_prefix, email, context, headers=None):
-        # Fix non-configurable URLs in email templates to go to correct custom URLs.
-        if "signup_url" in context:
-            context["signup_url"] = build_absolute_uri(self.request, reverse("signup"))
-
-        if "password_reset_url" in context:
-            key = context["password_reset_url"].split("/key/", 1)[1]
-            (uidb36, key) = re.match(
-                r"^(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$", key
-            ).groups()
-            print(key)
-            context["password_reset_url"] = build_absolute_uri(
-                self.request,
-                reverse(
-                    "account_reset_password_from_key",
-                    kwargs={"key": key, "uidb36": uidb36},
-                ),
-            )
-
         # Set the REPLY-TO header on all emails.
         if settings.DEFAULT_REPLY_TO_EMAIL is not None:
             if headers is None:

--- a/users/templates/account/email/account_already_exists_message.txt
+++ b/users/templates/account/email/account_already_exists_message.txt
@@ -1,0 +1,19 @@
+{% extends "account/email/base_message.txt" %}
+{% load i18n %}
+
+{% block content %}{% autoescape off %}{% blocktrans %}
+
+You are receiving this email because you or someone else tried to sign up to
+GO-EV Car Share using the email address:
+
+{{ email }}
+
+However, an account using that email address already exists.  If you do not
+remeber your password, please use the link below to reset it:
+
+{{ password_reset_url }}
+
+Regards,
+
+The GO-EV Team
+{% endblocktrans %}{% endautoescape %}{% endblock content %}

--- a/users/templates/account/email/account_already_exists_subject.txt
+++ b/users/templates/account/email/account_already_exists_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Your GO-EV Car Share account already exists{% endblocktrans %}
+{% endautoescape %}

--- a/users/templates/account/email/unknown_account_message.txt
+++ b/users/templates/account/email/unknown_account_message.txt
@@ -5,11 +5,15 @@
 password reset for your GO-EV Car Share account. However, we do not have any record of a user
 with email {{ email }} in our database.
 
-** If you are activating your GO-EV account on our new system, then this message means that you have used the wrong email address. If you are not sure what email address your GO-EV account is linked to, then please contact us on {{ CONTACT_EMAIL }} or {{ CONTACT_PHONE }} for help.**
+** If you are activating your GO-EV account on our new system for the first time, then
+this message means that you have used the wrong email address. If you are not sure what
+email address your GO-EV account is linked to, then please contact us on {{ CONTACT_EMAIL }}
+or {{ CONTACT_PHONE }} for help.**
 
 If you did not request a password reset, you can safely ignore this email.
 
-If it was you, you can sign up for an account using the link below.{% endblocktrans %}
+If you did request a password reset, then you can sign up for an account using
+the link below.
 
 {{ signup_url }}
 
@@ -17,4 +21,4 @@ Regards,
 
 The GO-EV Team
 
-{% endautoescape %}{% endblock %}
+{% endblocktrans %}{% endautoescape %}{% endblock %}

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -34,7 +34,7 @@
           </div>
         </form>
         <div class="text-center text-sm">
-          <a href="{% url 'users_password_reset' %}" class="text-blue-600 hover:text-blue-500">I've forgotten my
+          <a href="{% url 'account_reset_password' %}" class="text-blue-600 hover:text-blue-500">I've forgotten my
             password.</a>
         </div>
       </div>

--- a/users/urls.py
+++ b/users/urls.py
@@ -4,9 +4,31 @@ from django.urls import path, re_path
 from . import views
 
 urlpatterns = [
-    path("incomplete/", views.incomplete, name="users_incomplete"),
+    # AllAuth account-related URL overrides
     path("signup/", views.SignUpView.as_view(), name="account_signup"),
     path("login/", views.LoginView.as_view(), name="account_login"),
+    path("logout/", allauthviews.logout, name="account_logout"),
+    path(
+        "password/reset/",
+        views.PasswordResetView.as_view(),
+        name="account_reset_password",
+    ),
+    re_path(
+        r"^password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$",
+        views.PasswordResetFromKeyView.as_view(),
+        name="account_reset_password_from_key",
+    ),
+    path(
+        "password/reset/done/",
+        views.PasswordResetDoneView.as_view(),
+        name="account_password_reset_done",
+    ),
+    path(
+        "password/reset/key/done/",
+        views.PasswordResetFromKeyDoneView.as_view(),
+        name="account_password_reset_key_done",
+    ),
+    # Email Confirmation
     path(
         "email-verification-sent/",
         views.EmailVerificationSentView.as_view(),
@@ -17,6 +39,7 @@ urlpatterns = [
         views.ConfirmEmailView.as_view(),
         name="confirm_email",
     ),
+    # Users app business logic routes
     path(
         "mobile/add/",
         views.add_mobile,
@@ -32,25 +55,5 @@ urlpatterns = [
         views.profile_my_details,
         name="users_profile_my_details",
     ),
-    path(
-        "password/reset/",
-        views.PasswordResetView.as_view(),
-        name="users_password_reset",
-    ),
-    path(
-        "password/reset/done/",
-        views.PasswordResetDoneView.as_view(),
-        name="users_password_reset_done",
-    ),
-    re_path(
-        r"^password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$",
-        views.PasswordResetFromKeyView.as_view(),
-        name="account_reset_password_from_key",
-    ),
-    path(
-        "password/reset/key/done/",
-        views.PasswordResetFromKeyDoneView.as_view(),
-        name="users_password_reset_key_done",
-    ),
-    path("logout/", allauthviews.logout, name="account_logout"),
+    path("incomplete/", views.incomplete, name="users_incomplete"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -62,7 +62,7 @@ class LoginView(views.LoginView):
 class PasswordResetView(views.PasswordResetView):
     template_name = "users/password_reset.html"
     form_class = ResetPasswordForm
-    success_url = reverse_lazy("users_password_reset_done")
+    success_url = reverse_lazy("account_password_reset_done")
 
 
 class PasswordResetDoneView(views.PasswordResetDoneView):
@@ -72,7 +72,7 @@ class PasswordResetDoneView(views.PasswordResetDoneView):
 class PasswordResetFromKeyView(views.PasswordResetFromKeyView):
     template_name = "users/password_reset_from_key.html"
     form_class = ResetPasswordKeyForm
-    success_url = reverse_lazy("users_password_reset_key_done")
+    success_url = reverse_lazy("account_password_reset_key_done")
 
 
 class PasswordResetFromKeyDoneView(views.PasswordResetFromKeyDoneView):


### PR DESCRIPTION
Fix two cases of error 500 occurring in production, and tidy up some associated code:

1. When entering an already used email into the sign up form an error 500 was 
     triggered instead of sending an email telling them to reset their password. 
2. When entering an unknown email into the log in form an error 500 was 
     triggered instead of sending an email to the address telling them they needed
     to sign up.

These issues were both observed through production error logging.