### PR TITLE
Reduce query count on bookings list.

### DIFF
--- a/bookings/views.py
+++ b/bookings/views.py
@@ -40,8 +40,12 @@ def home(request):
 @login_required
 @require_user_can_view_bookings
 def my_bookings(request):
-    bookings = Booking.objects.filter(user_id=request.user.id).order_by(
-        "-reservation_time"
+    bookings = (
+        Booking.objects.filter(user_id=request.user.id)
+        .order_by("-reservation_time")
+        .select_related("vehicle__box__current_booking")
+        .select_related("vehicle__bay__station")
+        .select_related("billing_account")
     )
     context = {
         "bookings": bookings,


### PR DESCRIPTION
Some recent change caused an O(n) database query where n is the size of the booking list. Once this hit production it made the bookings list page painfully slow to load for users with lots of bookings. I hope this is enough to fix it.