### PR TITLE
Reduce access checks in booking list.

### DIFF
--- a/bookings/templates/bookings/booking_list/booking_card.html
+++ b/bookings/templates/bookings/booking_list/booking_card.html
@@ -59,7 +59,6 @@
   </div>
   {% if booking.cancelled %}
   {% else %}
-    {% user_can_access_booking user booking as access %}
     <div>
       <div class="-mt-px flex divide-x divide-gray-200">
         {% if booking.reservation_in_progress %}
@@ -74,15 +73,18 @@
               <span class="ml-3">Edit</span>
             </a>
           </div>
+          {% user_can_access_booking user booking as access %}
           {% if access %}
             {% include "bookings/booking_list/unlock-button.html" %}
             {% include "bookings/booking_list/lock-button.html" %}
           {% endif %}
         {% elif booking.reservation_ended %}
-            {% if access and booking.is_current_booking_on_box %}
+          {% if booking.is_current_booking_on_box %}
+            {% user_can_access_booking user booking as access %}
+            {% if access %}
               {% include "bookings/booking_list/lock-button.html" %}
             {% endif %}
-            
+          {% endif %}
         {% else %}
           <div class="w-0 flex-1 flex">
             <a href="{% url 'bookings_edit' booking.id %}"


### PR DESCRIPTION
A previous commit moved the user_can_access_booking check to be in a different place in the code where it started to be called for every closed booking, of which there can be an awful lot. This is an expensive check that includes DB queries each time it is run. Refactor the code to only run it when other checks have deemed it necessary so it runs a lot less often and hopefully results in considerably less performance impact on users with lots of old closed bookings.