### PR TITLE
card_id leading zeros bug

### DIFF
--- a/hardware/views.py
+++ b/hardware/views.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 def parse_card_id(card_id):
-    return struct.unpack("<I", binascii.unhexlify(card_id))[0]
+    return binascii.unhexlify(card_id).decode("utf8")
 
 
 @csrf_exempt


### PR DESCRIPTION
fixes #64
Card IDs are stored in the database as charFields, they are for ID purposes so should be considered strings, they were previously converted to Integers by parse_card_id.