### PR TITLE
126 buffer time

### DIFF
--- a/bookings/models.py
+++ b/bookings/models.py
@@ -17,11 +17,11 @@ from billing.models import BillingAccount
 from billing.pricing import calculate_booking_cost
 from hardware.models import Vehicle
 from users.models import User
+from carshare.settings import POLICY_BUFFER_TIME
 
 log = logging.getLogger(__name__)
 
 POLICY_CANCELLATION_CUTOFF_HOURS = 2
-POLICY_BUFFER_TIME = 30
 MAX_BOOKING_END_DAYS = 120
 
 

--- a/carshare/settings.py
+++ b/carshare/settings.py
@@ -291,3 +291,5 @@ CONTACT_INTERNATIONAL_PHONE = os.environ.get(
 
 # old telemetry is deleted on the first of every month at 3am, it will be kept if younger than this value
 TELEMETRY_AGE_DAYS = int(os.environ.get("TELEMETRY_AGE_DAYS", 180))
+
+POLICY_BUFFER_TIME = int(os.environ.get("POLICY_BUFFER_TIME", 15))


### PR DESCRIPTION
fixes #126
Adds POLICY_BUFFER_TIME to carshare.settings loaded from an environment variable, defaulting to 15 minutes