### PR TITLE
Default recaptcha variables should be empty string not None

### DIFF
--- a/carshare/settings.py
+++ b/carshare/settings.py
@@ -240,8 +240,8 @@ STRIPE_PUBLIC_KEY = os.environ.get("STRIPE_PUBLIC_KEY", None)
 stripe.api_key = STRIPE_API_KEY
 
 # Recaptcha
-RECAPTCHA_PUBLIC_KEY = os.environ.get("RECAPTCHA_PUBLIC_KEY", None)
-RECAPTCHA_PRIVATE_KEY = os.environ.get("RECAPTCHA_PRIVATE_KEY", None)
+RECAPTCHA_PUBLIC_KEY = os.environ.get("RECAPTCHA_PUBLIC_KEY", "")
+RECAPTCHA_PRIVATE_KEY = os.environ.get("RECAPTCHA_PRIVATE_KEY", "")
 
 # Base URL
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:8000")


### PR DESCRIPTION
Otherwise running `manage.py` without the env vars set breaks, which breaks CI builds.