### PR TITLE
typo in password reset email

### DIFF
--- a/users/templates/account/email/account_already_exists_message.txt
+++ b/users/templates/account/email/account_already_exists_message.txt
@@ -9,7 +9,7 @@ GO-EV Car Share using the email address:
 {{ email }}
 
 However, an account using that email address already exists.  If you do not
-remeber your password, please use the link below to reset it:
+remember your password, please use the link below to reset it:
 
 {{ password_reset_url }}
 


### PR DESCRIPTION
In the password reset email remember had an m missing (remeber).