### PR TITLE
cancelled bookings toggle

### DIFF
--- a/backoffice/templates/backoffice/bookings/status_colour.html
+++ b/backoffice/templates/backoffice/bookings/status_colour.html
@@ -1,7 +1,7 @@
 {% if status == 'pending' %}<tr class="bg-yellow-100 sm:bg-white text-black sm:text-gray-500">
 {% elif status == 'active' %}<tr class="bg-green-200 sm:bg-white text-black sm:text-gray-500">
 {% elif status == 'inactive' %}<tr class="bg-blue-200 sm:bg-white text-black sm:text-gray-500">
-{% elif status == 'cancelled' %}<tr class="bg-gray-300 sm:bg-white text-black sm:text-gray-500">
+{% elif status == 'cancelled' %}<tr class="bg-gray-300 sm:bg-white text-black sm:text-gray-500 cancelled">
 {% elif status == 'late' %}<tr class="bg-red-100 sm:bg-white text-black sm:text-gray-500">
 {% elif status == 'ended' %}<tr class="bg-purple-200 sm:bg-white text-black sm:text-gray-500">
 {% elif status == 'billed' %}<tr class="bg-gray-100 sm:bg-white text-black sm:text-gray-500">

--- a/backoffice/templates/backoffice/home.html
+++ b/backoffice/templates/backoffice/home.html
@@ -28,8 +28,31 @@
   {% endif %}
   <div class="p-4 sm:p-6 lg:p-8">
     <div class="sm:flex sm:items-center">
-      <div class="sm:flex-auto">
+      <div class="flex flex-row flex-wrap gap-4">
         <h1 class="text-xl font-semibold text-gray-900">Today and Tomorrow's bookings</h1>
+        <label class="inline-flex items-center cursor-pointer" id="cancelled_label">
+          <input type="checkbox" value="" class="sr-only peer" id="cancelled_value">
+          <div class="relative w-9 h-5 bg-teal-400 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-buffer after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-teal-800"></div>
+          <span class="select-none ms-1 text-sm font-medium text-heading">Show/Hide Cancelled Bookings</span>
+        </label>
+        <script>
+          const cancelled_value=document.getElementById('cancelled_value');
+          const cancelled_label=document.getElementById('cancelled_label');
+          
+          cancelled_value.checked = params.get('cancelled') === 'false';
+          cancelled_label.addEventListener('pointerup',(e)=>{
+            if(cancelled_value.checked){
+              document.querySelectorAll('.cancelled').forEach(row=>{
+                row.style.display='table-row';
+              })
+            }
+            else{
+              document.querySelectorAll('.cancelled').forEach(row=>{
+                row.style.display='none';
+              })
+            }
+          })
+        </script>
       </div>
     </div>
     <div class="mt-8 flex flex-col">

--- a/backoffice/templates/backoffice/home.html
+++ b/backoffice/templates/backoffice/home.html
@@ -36,22 +36,30 @@
           <span class="select-none ms-1 text-sm font-medium text-heading">Show/Hide Cancelled Bookings</span>
         </label>
         <script>
-          const cancelled_value=document.getElementById('cancelled_value');
-          const cancelled_label=document.getElementById('cancelled_label');
-          
-          cancelled_value.checked = params.get('cancelled') === 'false';
-          cancelled_label.addEventListener('pointerup',(e)=>{
-            if(cancelled_value.checked){
-              document.querySelectorAll('.cancelled').forEach(row=>{
-                row.style.display='table-row';
-              })
+          const cancelled_value = document.getElementById('cancelled_value');
+          const stylesheet =document.styleSheets[0];
+          const hide_cancelled = sessionStorage.getItem('hide_cancelled');
+
+          if(hide_cancelled === 'true'){
+            cancelled_value.checked = true;
+            updateCancelledRows()
+          }
+
+          function updateCancelledRows() {
+            for (const rule of stylesheet.cssRules){
+              if (rule.selectorText === '.cancelled'){
+                rule.style.display = cancelled_value.checked ? 'none' : 'table-row';
+              }
             }
-            else{
-              document.querySelectorAll('.cancelled').forEach(row=>{
-                row.style.display='none';
-              })
-            }
-          })
+          }
+
+          cancelled_value.addEventListener('change', async () => {
+            updateCancelledRows();
+
+            sessionStorage.setItem('hide_cancelled',
+             cancelled_value.checked ? 'true' : 'false'
+            );
+          });
         </script>
       </div>
     </div>

--- a/theme/static_src/src/styles.css
+++ b/theme/static_src/src/styles.css
@@ -14,6 +14,10 @@
     right:-4px;
 }
 
+.cancelled{
+    display:table-row;
+}
+
 @-webkit-keyframes checkmark {
     0% {
         stroke-dashoffset: 100px


### PR DESCRIPTION
fixes #143 
Adds toggle to "Today and Tomorrow's Bookings" table on the dashboard to show/hide cancelled bookings.
Stores the option in session storage and sets the display property of the .cancelled class accordingly.